### PR TITLE
Multiple buys

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -235,11 +235,13 @@ const buySecurity = async () => {
     price: ticker.Ask,
     buyOrSell: 0,
   });
-  log.info(`buySecurity: Buy ${buyLesserQuantity}${config.get('sienaAccount.securityCurrency')} for ${ticker.Ask} on ${new Date()}`);
+  log.info(`buySecurity, getTradeAmount: ${sienaAccount.getTradeAmount()}`);
+  log.info(`buySecurity: Buy ${buyLesserQuantity.toFixed(12)}${config.get('sienaAccount.securityCurrency')} for ${ticker.Ask} on ${new Date()}`);
   let order;
   try {
     await buyLimit(config.get('bittrexMarket'), buyLesserQuantity, ticker.Ask);
   } catch (err) {
+    // Watch out for MIN_TRADE_REQUIREMENT_NOT_MET
     log.error(`buySecurity, Error : ${err}`);
     transactionLock = false;
     return (false);

--- a/src/index.js
+++ b/src/index.js
@@ -239,7 +239,7 @@ const buySecurity = async () => {
   log.info(`buySecurity: Buy ${buyLesserQuantity.toFixed(12)}${config.get('sienaAccount.securityCurrency')} for ${ticker.Ask} on ${new Date()}`);
   let order;
   try {
-    await buyLimit(config.get('bittrexMarket'), buyLesserQuantity, ticker.Ask);
+    order = await buyLimit(config.get('bittrexMarket'), buyLesserQuantity, ticker.Ask);
   } catch (err) {
     // Watch out for MIN_TRADE_REQUIREMENT_NOT_MET
     log.error(`buySecurity, Error : ${err}`);

--- a/src/index.js
+++ b/src/index.js
@@ -170,13 +170,15 @@ const updateLastTradeTime = async (expectedBalance, action, price = undefined) =
   const balance = account.setBittrexBalance(await updateBalance());
   log.info(`updateLastTradeTime: actual balance:${balance}, expected balance: ${expectedBalance}.`);
   if (balance.toFixed(2) === expectedBalance.toFixed(2)) {
-    sienaAccount.trade(action, price);
     if (action === 'buy') {
+      sienaAccount.trade('buy', price);
       // Calculate the SELL trigger prices
       if (config.get('strategy.upperSell') === 'dynamic') {
         upperSellPercentage = await getUpperSellPercentage(sienaAccount.getLastAverageBuyPrice());
       }
       logSellTriggerPrices(upperSellPercentage, sienaAccount.getLastAverageBuyPrice());
+    } else {
+      sienaAccount.trade('sell', price);
     }
 
     lastTrade = action;

--- a/src/index.js
+++ b/src/index.js
@@ -176,7 +176,7 @@ const updateLastTradeTime = async (expectedBalance, action, price = undefined) =
       if (config.get('strategy.upperSell') === 'dynamic') {
         upperSellPercentage = await getUpperSellPercentage(sienaAccount.getLastAverageBuyPrice());
       }
-      logSellTriggerPrices(upperSellPercentage, sienaAccount.getLastBuyPrice());
+      logSellTriggerPrices(upperSellPercentage, sienaAccount.getLastAverageBuyPrice());
     }
 
     lastTrade = action;
@@ -396,7 +396,7 @@ updateBalance().then(async (bittrexBalances) => {
     }
 
     log.info(`updateBalance, lastBuyPrice: ${sienaAccount.getLastBuyPrice()}`);
-    logSellTriggerPrices(upperSellPercentage, sienaAccount.getLastBuyPrice());
+    logSellTriggerPrices(upperSellPercentage, sienaAccount.getLastAverageBuyPrice());
   }
   log.info(`updateBalance, lastTrade: ${lastTrade}`);
 

--- a/src/nav.js
+++ b/src/nav.js
@@ -1,10 +1,16 @@
 const config = require('config');
 const bunyan = require('bunyan');
 const getNetAssetValue = require('./lib/get-net-asset-value');
+const getBalances = require('./lib/get-balances');
 
 const log = bunyan.createLogger({ name: 'nav' });
 
 (async () => {
-  const nav = await getNetAssetValue();
+  const tasks = [
+    getNetAssetValue(),
+    getBalances(),
+  ];
+  const [nav, bittrexBalances] = await Promise.all(tasks);
+  log.info(bittrexBalances);
   log.info(`The current net asset value of your bittrex account trading with the ${config.get('bittrexMarket')} market is $${nav} USD`);
 })();

--- a/src/strategy/index.js
+++ b/src/strategy/index.js
@@ -1,5 +1,7 @@
 const simpleMovingAverage = require('./simple-moving-average.js');
+const simpleMovingAverageMutipleBuys = require('./simple-moving-average-multiple-buys.js');
 
 module.exports = {
   simpleMovingAverage,
+  simpleMovingAverageMutipleBuys,
 };

--- a/src/strategy/simple-moving-average-multiple-buys.js
+++ b/src/strategy/simple-moving-average-multiple-buys.js
@@ -1,0 +1,82 @@
+const config = require('config');
+const _ = require('lodash');
+
+module.exports = [{
+  condition: function condition(R) {
+    R.when(_.has(this, 'principle') &&
+     _.has(this, 'currentAccountValue') &&
+     this.currentAccountValue < (this.principle - (config.get('sienaAccount.criticalPoint') * this.principle)));
+  },
+  consequence: function consequence(R) {
+    // Market has crashed and your capital has eroded, Bail out!
+    this.actions = ['halt'];
+    R.stop();
+  },
+}, {
+  condition: function condition(R) {
+    R.when(_.has(this, 'bittrexAccountBalances'));
+  },
+  consequence: function consequence(R) {
+    this.actions = ['compartmentaliseAccount'];
+    R.stop();
+  },
+}, {
+  condition: function condition(R) {
+    R.when(_.has(this, 'movingAverageShort') &&
+      _.has(this, 'movingAverageMid') &&
+      _.has(this, 'movingAverageLong'));
+  },
+  consequence: function consequence(R) {
+    this.actions = ['getMarketTrend', 'getAccountValue'];
+    R.stop();
+  },
+}, {
+  condition: function condition(R) {
+    R.when(_.has(this, 'event') &&
+      _.has(this, 'market') &&
+      _.has(this, 'lastTrade') &&
+      _.has(this, 'currentBidPrice') &&
+      this.event === 'crossover' &&
+      this.market === 'bull' &&
+      this.lastTrade !== 'buy');
+  },
+  consequence: function consequence(R) {
+    // Buy security at the start of a bull run
+    this.actions = ['buySecurity'];
+    R.stop();
+  },
+}, {
+  condition: function condition(R) {
+    R.when(_.has(this, 'event') &&
+      _.has(this, 'lastTrade') &&
+      _.has(this, 'market') &&
+      _.has(this, 'lastAverageBuyPrice') &&
+      _.has(this, 'currentBidPrice') &&
+      _.has(this, 'upperSellPercentage') &&
+      this.event === 'crossover' &&
+      this.currentBidPrice > (this.lastAverageBuyPrice +
+        (this.upperSellPercentage * this.lastAverageBuyPrice)) &&
+      this.lastTrade === 'buy' &&
+      this.market !== 'bull');
+  },
+  consequence: function consequence(R) {
+    // You've got a profit so cash in!
+    this.actions = ['sellSecurity'];
+    R.stop();
+  },
+}, {
+  condition: function condition(R) {
+    R.when(_.has(this, 'lastTrade') &&
+      _.has(this, 'market') &&
+      _.has(this, 'lastBuyPrice') &&
+      _.has(this, 'currentBidPrice') &&
+      this.currentBidPrice < (this.lastBuyPrice - (config.get('strategy.lowerBuyPercentage') * this.lastBuyPrice)) &&
+      this.lastTrade === 'buy' &&
+      this.market === 'bull');
+  },
+  consequence: function consequence(R) {
+    // Buy a little more at a lower price
+    this.actions = ['buySecurity'];
+    R.stop();
+  },
+}];


### PR DESCRIPTION
Added a new strategy.
- The strategy will not buy security for all the available currency. It only buys for the amount that is compartmentalised for trade.
- The main index.js has some more useful logging.
- Net asset value script will show all the amounts in your bittrex wallets.